### PR TITLE
Feature request: mock interfaces and methods that return arrays

### DIFF
--- a/lib/Class/Mock/Generic/InterfaceTester.pm
+++ b/lib/Class/Mock/Generic/InterfaceTester.pm
@@ -285,6 +285,13 @@ sub AUTOLOAD {
         );
         return;
     }
+
+    # Sometimes the method you mock returns void, arrays or hashes.
+    # Pass in a code-ref that returns them
+    if (ref $next_test->{output} eq 'CODE') {
+        return $next_test->{output}->();
+    }
+
     return $next_test->{output};
 }
 

--- a/lib/Class/Mock/Method/InterfaceTester.pm
+++ b/lib/Class/Mock/Method/InterfaceTester.pm
@@ -76,6 +76,10 @@ sub new {
             }
         }
 
+        if ( ref($this_test->{output}) eq 'CODE' ) {
+          return $this_test->{output}->();
+        }
+
         return $this_test->{output};
     }, $class);
 }

--- a/t/class-mock-generic-interfacetester.t
+++ b/t/class-mock-generic-interfacetester.t
@@ -4,7 +4,7 @@ use warnings;
 package CMGITtests;
 
 use Config;
-use Test::More tests => 10;
+use Test::More tests => 11;
 use Capture::Tiny qw(capture);
 use Class::Mock::Generic::InterfaceTester;
 
@@ -51,9 +51,11 @@ sub didnt_run_all_tests {
 sub correct_method_call_gets_correct_results {
     my $interface = Class::Mock::Generic::InterfaceTester->new([
         { method => 'foo', input => ['foo'], output => 'foo' },
+        { method => 'foo', input => ['bar'], output => sub { qw/bar baz/ } },
     ]);
 
     ok($interface->foo('foo') eq 'foo', "correct method call gets right result back");
+    is_deeply([$interface->foo('bar')], [qw/bar baz/], "pass a code ref to return arrays and hashes");
 }
 
 sub run_out_of_tests {

--- a/t/test-classes/CMMITTests.pm
+++ b/t/test-classes/CMMITTests.pm
@@ -84,7 +84,7 @@ sub wrong_args_subref :Tests(2) {
     );
 }
 
-sub correct_method_call_gets_correct_results :Tests(2) {
+sub correct_method_call_gets_correct_results :Tests(3) {
     CMMITTestClass->_reset_test_method();
     ok(CMMITTestClass->_test_method('foo') eq "called test_method on CMMITTestClass with [foo]\n",
         "calling a method after _reset()ing works"
@@ -93,10 +93,12 @@ sub correct_method_call_gets_correct_results :Tests(2) {
     CMMITTestClass->_set_test_method(
         Class::Mock::Method::InterfaceTester->new([
             { input => ['foo'], output => 'foo' },
+            { input => ['bar'], output => sub {'coderef called'} },
         ])
     );
 
     ok(CMMITTestClass->_test_method('foo') eq 'foo', "correct method call gets right result back");
+    is(CMMITTestClass->_test_method('bar') => 'coderef called', "correct method call gets result back from code-ref");
 }
 
 sub run_out_of_tests :Tests(1) {


### PR DESCRIPTION
Class::Mock::\* look like they can mock interfaces that return scalar or refs. Any thoughts on mocking interfaces that return void, arrays or hashes?

The pull request does it by letting you pass in a code ref to generate what is returned
