### PR TITLE
Add much-needed sugar

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
-XXXX-XX-XX      XXXX    Add note to doco about namespace::autoclean
+XXXX-XX-XX      XXXX    Let people add fixtures to an existing
+                        C::M::G::IT object, with convenient shorthands.
+
+                        Add note to doco about namespace::autoclean
 
 2013-01-14      1.11    Add Class::Mock::Method::InterfaceTester
 

--- a/lib/Class/Mock/Generic/InterfaceTester.pm
+++ b/lib/Class/Mock/Generic/InterfaceTester.pm
@@ -294,7 +294,8 @@ sub new {
                 $method,
                 $caller
             )
-        }
+        },
+        tests => [],
     }, $class);
     if (@_) {
         $_add_fixtures->($self, @_);

--- a/lib/Class/Mock/Generic/InterfaceTester.pm
+++ b/lib/Class/Mock/Generic/InterfaceTester.pm
@@ -51,16 +51,44 @@ and in the tests:
         ]);
     );
 
+or, more simply:
+
+    my $interface_tester = Class::Mock::Generic::InterfaceTester->new;
+    My::Module->_storage_class($interface_tester);
+    
+    # Expect this method to be called by this test.
+    $interface_tester->add_fixtures(
+        fetch => {
+            input => [customer_id => 94],
+            output => ...
+        },
+    );
+    ok(My::Module->something_that_fetches_from_storage(customer_id => 94));
+
+    # Expect these two methods to be called by this next test.
+    $interface_tester->add_fixtures(
+        update => {
+            input  => [status => 'fired', reason => 'non-payment'],
+            output => 1,
+        },
+        uuid => {
+            output => 'DEADBEEF-1234-5678-9ABC-1234567890AB',
+        }
+    );
+    ok(My::Module->something_that_updates_storage_for_non_payment);
+
 =head1 METHODS
 
 =head2 new
 
-This is the only real method.  It creates a very simple object.  Pass
-to it an arrayref of fixtures structured as above.  Any subsequent
-method calls on that object are handled by AUTOLOAD.  Note that because
+ In: \@fixtures or @fixtures
+
+This is the main method. It creates a very simple object. Pass to it a list or
+arrayref of fixtures (see L<add_fixtures> for syntax). Any subsequent method
+calls on that object are handled by AUTOLOAD. Note that because
 the constructor is Highly Magical you can even provide fixtures for a
 method called 'new()'.  The only ones you can't provide fixtures for are
-'AUTOLOAD()' and 'DESTROY()'.
+'AUTOLOAD()' and 'DESTROY()', and possibly L<add_fixtures>.
 
 For each method call, the first element is removed from the array of
 fixtures.  We then compare the name of the method that was called with
@@ -83,6 +111,50 @@ In this case, the actual parameters passed to the method will be passed to
 that code-ref for validation.  It should return true if the params are OK
 and false otherwise.  In the example, it will return true if the hash of
 args contains a 'fruit' key with value 'apple'.
+
+=head2 add_fixtures
+
+ In: \@fixtures or @fixtures
+
+Supplied with either an arrayref or a list of method call fixtures, adds them
+to the array of fixtures this object maintains internally (although see below
+for a caveat about this).
+
+At the simplest, a method call fixture is a hashref with keys
+C<method>, C<input> and C<output>. If you don't care about the input
+your method receives, you can omit that key and any input will be accepted.
+
+You can also provide a fixture as a pair of C<method> and (hashref containing
+input and output). This lets you write a series of method call fixtures as an
+apparent ordered hash, which may feel more natural. As above, you can omit
+the input field if you don't care. So the following calls are equivalent:
+
+ $interface_tester->add_fixtures(
+     [
+         {
+             method => 'do_something',
+             input  => sub { 1 },
+             output => 'Yup, done',
+         },
+         {
+             method => 'do_something_with_this',
+             input  => ['fish'],
+             output => 'Fish cooked',
+         }
+     ]
+ );
+
+ $interface_tester->add_fixtures(
+     do_something           => { output => 'Yup, done' },
+     do_something_with_this => {
+         input  => ['fish'],
+         output => 'Fish cooked',
+     },
+ );
+
+Caveat: just in case you need to test a call to a method that coincidentally
+is also called C<add_fixtures>, this method is only enabled
+if you did I<not> provide a list of fixtures to the constructor.
 
 =head2 DESTROY
 
@@ -200,6 +272,8 @@ care more about how you call external code.
 
 =cut
 
+my $_add_fixtures;
+
 sub new {
     my $class = shift;
 
@@ -211,9 +285,8 @@ sub new {
     }
 
     my $caller = (caller(1))[3];
-    return bless({
+    my $self = bless({
         called_from => $caller,
-        tests => shift,
         _origin_message => sub {
             my $method = shift;
             return sprintf(
@@ -223,12 +296,57 @@ sub new {
             )
         }
     }, $class);
+    if (@_) {
+        $_add_fixtures->($self, @_);
+    } else {
+        $self->{_no_fixtures_in_constructor} = 1;
+    }
+    return $self;
 }
+
+# Declaring this as a coderef rather than a method so we can decide
+# whether it exists or not based on how the constructor was called,
+# for maximum backwards-compatibility.
+
+$_add_fixtures = sub {
+    my $self = shift;
+
+    # We might have been passed an arrayref or a list.
+    my @args = (ref($_[0]) eq 'ARRAY' && @_ == 1) ? @{$_[0]} : @_;
+
+    # Our fixtures might be raw hashrefs, or method name => hashref pairs.
+    # You can't mix and match.
+    my @fixtures;
+    if (ref($args[0]) eq 'HASH') {
+        @fixtures = @args;
+    } else {
+        while (my ($method, $fixture_details) = splice(@args, 0, 2)) {
+            push @fixtures, { method => $method, %$fixture_details };
+        }
+    }
+
+    # If input is omitted, we assume we don't care.
+    for (@fixtures) {
+        if (!exists $_->{input}) {
+            $_->{input} = sub { 1 };
+        }
+    }
+
+    # OK, add these fixtures.
+    push @{ $self->{tests} ||= [] }, @fixtures;
+};
 
 sub AUTOLOAD {
     (my $method = $AUTOLOAD) =~ s/.*:://;
     my $self = shift;
     my @args = @_;
+
+    # If this is the special method add_fixtures, and we didn't
+    # add fixtures in the constructor (i.e. we expect to add fixtures
+    # bit by bit rather than all at once), add fixtures to our list.
+    if ($method eq 'add_fixtures' && $self->{_no_fixtures_in_constructor}) {
+        return $_add_fixtures->($self, @args);
+    }
 
     # If we have no more tests, then we've called the mocked $thing more
     # times than expected - the code under test obviously has more outputs

--- a/lib/Class/Mock/Generic/InterfaceTester.pm
+++ b/lib/Class/Mock/Generic/InterfaceTester.pm
@@ -3,6 +3,7 @@ package Class::Mock::Generic::InterfaceTester;
 use strict;
 use warnings;
 
+### FIXME: shouldn't this be 1.11?
 our $VERSION = '1.0';
 
 use vars qw($AUTOLOAD);

--- a/t/class-mock-generic-interfacetester.t
+++ b/t/class-mock-generic-interfacetester.t
@@ -4,7 +4,7 @@ use warnings;
 package CMGITtests;
 
 use Config;
-use Test::More tests => 13;
+use Test::More tests => 15;
 use Capture::Tiny qw(capture);
 use Class::Mock::Generic::InterfaceTester;
 
@@ -160,6 +160,27 @@ sub add_fixtures_arrayref {
         'More than one');
 }
 
-sub add_fixtures_list { }
+sub add_fixtures_list {
+    my $interface_tester = Class::Mock::Generic::InterfaceTester->new;
+    $interface_tester->add_fixtures(
+        {
+            method => 'brood',
+            input  => [{ style => 'teenager', glower => 'yes', }],
+            output => 'Excellent gloom',
+        },
+        {
+            method => 'sulk',
+            input  => ['endlessly'],
+            output => 'Woe!',
+        }
+    );
+    is(
+        $interface_tester->brood({ glower => 'yes', style => 'teenager' }),
+        'Excellent gloom',
+        'You can add a method fixture as a list'
+    );
+    is($interface_tester->sulk('endlessly'), 'Woe!',
+        'And another');
+}
 sub add_fixtures_ordered_hash { }
 sub add_fixtures_input_omitted { }

--- a/t/class-mock-generic-interfacetester.t
+++ b/t/class-mock-generic-interfacetester.t
@@ -4,11 +4,23 @@ use warnings;
 package CMGITtests;
 
 use Config;
-use Test::More tests => 10;
+use Test::More tests => 11;
 use Capture::Tiny qw(capture);
 use Class::Mock::Generic::InterfaceTester;
 
-# mock _ok in C::M::G::IT
+# Basics: if we mock a method call fixture, it works.
+correct_method_call_gets_correct_results();
+
+# The various ways we have of adding fixtures work fine.
+add_fixtures_method_not_mocked();
+add_fixtures_arrayref();
+add_fixtures_list();
+add_fixtures_ordered_hash();
+add_fixtures_input_omitted();
+
+# mock _ok in C::M::G::IT so any reported failure is considered a success.
+# That only applies to this version of the Perl interpreter; shelling out
+# and calling C::M::G::IT with bad fixtures still results in a failure.
 Class::Mock::Generic::InterfaceTester->_ok(sub { Test::More::ok(!shift(), shift()); });
 
 default_ok();
@@ -32,7 +44,14 @@ sub default_ok {
         || diag($result);
 }
 
-correct_method_call_gets_correct_results();
+# Now that we've done that, we can test all sorts of ways that things can
+# go wrong, and consider C::M::G::IT complaining about something as a
+# test success. We list the expected test failures in the plan above,
+# so just saying Test::More::done_testing at the end is insufficient:
+# that wouldn't distinguish between (a) a test ran and did nothing, and
+# (b) a test produced an error, which we turned into a test success,
+# and counted.
+
 run_out_of_tests();
 wrong_method();
 wrong_args_structure();
@@ -100,3 +119,26 @@ sub magic_for_new {
     ok($interface->new('foo') eq 'foo', "\$mockobject->new() returns right data");
     $interface->new('bar'); # should emit an ok(1, "wrong args to method ...");
 }
+
+sub add_fixtures_method_not_mocked {
+    my $interface_tester = Class::Mock::Generic::InterfaceTester->new(
+        [
+            {
+                method => 'add_fixtures',
+                input  => ['curtain rail', 'picture hook'],
+                output => 'Picture hung!',
+            }
+        ]
+    );
+    is(
+        $interface_tester->add_fixtures('curtain rail', 'picture hook'),
+        'Picture hung!',
+        q{The method add_fixtures isn't magical if you supplied}
+            . ' a list of fixtures to the constructor'
+    );
+}
+
+sub add_fixtures_arrayref { } 
+sub add_fixtures_list { }
+sub add_fixtures_ordered_hash { }
+sub add_fixtures_input_omitted { }

--- a/t/class-mock-generic-interfacetester.t
+++ b/t/class-mock-generic-interfacetester.t
@@ -4,7 +4,7 @@ use warnings;
 package CMGITtests;
 
 use Config;
-use Test::More tests => 11;
+use Test::More tests => 13;
 use Capture::Tiny qw(capture);
 use Class::Mock::Generic::InterfaceTester;
 
@@ -138,7 +138,28 @@ sub add_fixtures_method_not_mocked {
     );
 }
 
-sub add_fixtures_arrayref { } 
+sub add_fixtures_arrayref {
+    my $interface_tester = Class::Mock::Generic::InterfaceTester->new;
+    $interface_tester->add_fixtures(
+        [
+            {
+                method => 'frolic',
+                input  => ['joyously'],
+                output => 'yay!',
+            },
+            {
+                method => 'celebrate',
+                input  => sub { 1 },
+                output => q{It's your birthday!},
+            }
+        ]
+    );
+    is($interface_tester->frolic('joyously'), 'yay!',
+        'You can add a method fixture as an arrayref');
+    is($interface_tester->celebrate, q{It's your birthday!},
+        'More than one');
+}
+
 sub add_fixtures_list { }
 sub add_fixtures_ordered_hash { }
 sub add_fixtures_input_omitted { }

--- a/t/class-mock-generic-interfacetester.t
+++ b/t/class-mock-generic-interfacetester.t
@@ -4,7 +4,7 @@ use warnings;
 package CMGITtests;
 
 use Config;
-use Test::More tests => 18;
+use Test::More tests => 20;
 use Capture::Tiny qw(capture);
 use Class::Mock::Generic::InterfaceTester;
 
@@ -216,4 +216,32 @@ sub add_fixtures_ordered_hash {
     );
 }
 
-sub add_fixtures_input_omitted { }
+sub add_fixtures_input_omitted {
+    my $interface_tester = Class::Mock::Generic::InterfaceTester->new;
+    $interface_tester->add_fixtures(
+        [
+            {
+                method => 'blow_things_up',
+                output => 'Boom!',
+            }
+        ]
+    );
+    is(
+        $interface_tester->blow_things_up(
+            q{It doesn't matter what I want to blow up}
+        ),
+        'Boom!',
+        'If you omit input, its exact value is ignored'
+    );
+    $interface_tester->add_fixtures(
+        blow_things_up_again => {
+            output => 'Boom! Boom! Boom for everyone!',
+        }
+    );
+    like(
+        $interface_tester->blow_things_up_again(
+            qw(tinky-winky laa-laa dipsy po )),
+        qr/Boom/,
+        'This works for shorthand fixtures as well'
+    );
+}

--- a/t/class-mock-generic-interfacetester.t
+++ b/t/class-mock-generic-interfacetester.t
@@ -4,7 +4,7 @@ use warnings;
 package CMGITtests;
 
 use Config;
-use Test::More tests => 15;
+use Test::More tests => 18;
 use Capture::Tiny qw(capture);
 use Class::Mock::Generic::InterfaceTester;
 
@@ -182,5 +182,38 @@ sub add_fixtures_list {
     is($interface_tester->sulk('endlessly'), 'Woe!',
         'And another');
 }
-sub add_fixtures_ordered_hash { }
+
+sub add_fixtures_ordered_hash {
+    my $interface_tester = Class::Mock::Generic::InterfaceTester->new;
+    $interface_tester->add_fixtures(
+        rock => {
+            input  => ['horns'],
+            output => 'metal AF',
+        },
+        paper => {
+            input  => [{ over => 'cracks' }],
+            output => 'Totally covered',
+        },
+        scissors => {
+            input  => ['Attractive woman', 'Other attractive woman'],
+            output => 'Not going to happen',
+        }
+    );
+    is($interface_tester->rock('horns'), 'metal AF',
+        'One call to our mocked interface');
+    is(
+        $interface_tester->paper({ over => 'cracks' }),
+        'Totally covered',
+        'And another with slightly fancy arguments'
+    );
+    is(
+        $interface_tester->scissors(
+            'Attractive woman',
+            'Other attractive woman'
+        ),
+        'Not going to happen',
+        'Arrayref arguments work as well'
+    );
+}
+
 sub add_fixtures_input_omitted { }


### PR DESCRIPTION
As discussed at $WORK, (1) let people specify fixtures in more convenient ways, and (2) bit by bit, rather than all at once, so you can keep fixture definitions next to individual tests.